### PR TITLE
Update setup.py to use thrift 0.9.0 (or later).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires = [
         'networkx',
         'testfixtures',
-        'thrift>=0.9.1',
+        'thrift>=0.9.0',
         ],
 
     url = "https://github.com/hltcoe/concrete-python",


### PR DESCRIPTION
@charman - let's switch to thrift 0.9.0 to be consistent with the java lib. 
